### PR TITLE
Revert "Fix issue with incorrect work of strtolower for Turkish"

### DIFF
--- a/Sources/LightPortal/Helper.php
+++ b/Sources/LightPortal/Helper.php
@@ -248,7 +248,7 @@ trait Helper
 
 	public function getSnakeName(string $value): string
 	{
-		return $this->smcFunc['strtolower'](preg_replace('/(?<!^)[A-Z]/', '_$0', $value));
+		return strtolower(preg_replace('/(?<!^)[A-Z]/', '_$0', $value));
 	}
 
 	public function getCamelName(string $value): string


### PR DESCRIPTION
For Turkish, it fixes issues with ImageUpload, UserInfo, etc. (all plugins that contain "I" in their names.