### PR TITLE
Add support of Sass compiler

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -31,6 +31,7 @@
         <include name="Themes/**" />
         <exclude name="Themes/default/LightPortal/components/**" />
         <exclude name="Themes/default/css/light_portal/less/**" />
+        <exclude name="Themes/default/css/light_portal/sass/**" />
         <exclude name="Themes/default/css/light_portal/plugins.css" />
         <exclude name="Themes/default/scripts/light_portal/dev/**" />
         <exclude name="Themes/default/scripts/light_portal/app*" />

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
       "pnpm run build",
       "pnpm run build:comments",
       "pnpm run build:plugins",
-      "pnpm run build:less"
+      "pnpm run build:sass"
     ],
     "up": [
       "cd src/Sources/LightPortal && composer update --no-dev -o",

--- a/configs/vite.sass.js
+++ b/configs/vite.sass.js
@@ -1,0 +1,18 @@
+import { resolve } from 'path';
+import { defineConfig } from 'vite';
+
+const dist = resolve('./src/Themes/default/css/light_portal');
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  build: {
+    outDir: dist,
+    emptyOutDir: false,
+    rollupOptions: {
+      input: 'src/Themes/default/css/light_portal/sass/portal.scss',
+      output: {
+        assetFileNames: 'portal.css',
+      },
+    },
+  },
+});

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build:comments": "vite build --config=configs/vite.comments.js",
     "build:plugins": "vite build --config=configs/vite.plugins.js",
     "build:less": "vite build --config=configs/vite.less.js",
+    "build:sass": "vite build --config=configs/vite.sass.js",
     "preview": "vite preview",
     "preinstall": "npx only-allow pnpm"
   },
@@ -22,6 +23,7 @@
     "axios": "^1.6.7",
     "less": "^4.2.0",
     "pinia": "^2.1.7",
+    "sass": "^1.70.0",
     "sortablejs": "^1.15.2",
     "vanilla-lazyload": "^17.8.5",
     "virtual-select-plugin": "^1.0.41",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ dependencies:
   pinia:
     specifier: ^2.1.7
     version: 2.1.7(vue@3.4.16)
+  sass:
+    specifier: ^1.70.0
+    version: 1.70.0
   sortablejs:
     specifier: ^1.15.2
     version: 1.15.2
@@ -63,7 +66,7 @@ dependencies:
 devDependencies:
   vite:
     specifier: ^5.1.0
-    version: 5.1.0(less@4.2.0)
+    version: 5.1.0(less@4.2.0)(sass@1.70.0)
   vite-plugin-static-copy:
     specifier: ^1.0.1
     version: 1.0.1(vite@5.1.0)
@@ -473,7 +476,7 @@ packages:
       vite: ^5.0.0
       vue: ^3.2.25
     dependencies:
-      vite: 5.1.0(less@4.2.0)
+      vite: 5.1.0(less@4.2.0)(sass@1.70.0)
       vue: 3.4.16
     dev: false
 
@@ -619,7 +622,6 @@ packages:
     dependencies:
       normalize-path: 3.0.0
       picomatch: 2.3.1
-    dev: true
 
   /asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
@@ -638,14 +640,12 @@ packages:
   /binary-extensions@2.2.0:
     resolution: {integrity: sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==}
     engines: {node: '>=8'}
-    dev: true
 
   /braces@3.0.2:
     resolution: {integrity: sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==}
     engines: {node: '>=8'}
     dependencies:
       fill-range: 7.0.1
-    dev: true
 
   /buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
@@ -671,7 +671,6 @@ packages:
       readdirp: 3.6.0
     optionalDependencies:
       fsevents: 2.3.3
-    dev: true
 
   /clean-css@5.3.3:
     resolution: {integrity: sha512-D5J+kHaVb/wKSFcyyV75uCn8fiY4sV38XJoe4CUyGQ+mOU/fMVYUdH1hJC+CJQ5uY3EnW27SbJYS4X8BiLrAFg==}
@@ -791,7 +790,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       to-regex-range: 5.0.1
-    dev: true
 
   /follow-redirects@1.15.5:
     resolution: {integrity: sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==}
@@ -833,7 +831,6 @@ packages:
     engines: {node: '>= 6'}
     dependencies:
       is-glob: 4.0.3
-    dev: true
 
   /graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
@@ -872,29 +869,28 @@ packages:
     requiresBuild: true
     optional: true
 
+  /immutable@4.3.5:
+    resolution: {integrity: sha512-8eabxkth9gZatlwl5TBuJnCsoTADlL6ftEr7A4qgdaTsPyreilDSnUk57SO+jfKcNtxPa22U5KK6DSeAYhpBJw==}
+
   /is-binary-path@2.1.0:
     resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
     engines: {node: '>=8'}
     dependencies:
       binary-extensions: 2.2.0
-    dev: true
 
   /is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
-    dev: true
 
   /is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
     dependencies:
       is-extglob: 2.1.1
-    dev: true
 
   /is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
-    dev: true
 
   /is-what@3.14.1:
     resolution: {integrity: sha512-sNxgpk9793nzSs7bA6JQJGeIuRBQhAaNGG77kzYQgMkrID+lS6SlK07K5LaptscDlSaIgH+GPFzf+d75FVxozA==}
@@ -1003,7 +999,6 @@ packages:
   /normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
-    dev: true
 
   /param-case@3.0.4:
     resolution: {integrity: sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==}
@@ -1029,7 +1024,6 @@ packages:
   /picomatch@2.3.1:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
-    dev: true
 
   /pify@4.0.1:
     resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
@@ -1080,7 +1074,6 @@ packages:
     engines: {node: '>=8.10.0'}
     dependencies:
       picomatch: 2.3.1
-    dev: true
 
   /relateurl@0.2.7:
     resolution: {integrity: sha512-G08Dxvm4iDN3MLM0EsP62EDV9IuhXPR6blNz6Utcp7zyV3tr4HVNINt6MpaRWbxoOHT3Q7YN2P+jaHX8vUbgog==}
@@ -1124,6 +1117,15 @@ packages:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
     requiresBuild: true
     optional: true
+
+  /sass@1.70.0:
+    resolution: {integrity: sha512-uUxNQ3zAHeAx5nRFskBnrWzDUJrrvpCPD5FNAoRvTi0WwremlheES3tg+56PaVtCs5QDRX5CBLxxKMDJMEa1WQ==}
+    engines: {node: '>=14.0.0'}
+    hasBin: true
+    dependencies:
+      chokidar: 3.6.0
+      immutable: 4.3.5
+      source-map-js: 1.0.2
 
   /sax@1.3.0:
     resolution: {integrity: sha512-0s+oAmw9zLl1V1cS9BtZN7JAd0cW5e0QH4W3LWEK6a4LaLEA2OTpGYWDY+6XasBLtz6wkm3u1xRw95mRuJ59WA==}
@@ -1183,7 +1185,6 @@ packages:
     engines: {node: '>=8.0'}
     dependencies:
       is-number: 7.0.0
-    dev: true
 
   /tooltip-plugin@1.0.16:
     resolution: {integrity: sha512-bZTFoMw2UM9dX9R6hZIme2vrMLvctdmqGDhzalXGrlxKGzRGTTSnpN6MAGvFf2aXOYfuRwQAhhoTLaleEnI4PQ==}
@@ -1213,7 +1214,7 @@ packages:
       vite: '*'
     dependencies:
       html-minifier-terser: 6.1.0
-      vite: 5.1.0(less@4.2.0)
+      vite: 5.1.0(less@4.2.0)(sass@1.70.0)
     dev: false
 
   /vite-plugin-static-copy@1.0.1(vite@5.1.0):
@@ -1226,10 +1227,10 @@ packages:
       fast-glob: 3.3.2
       fs-extra: 11.2.0
       picocolors: 1.0.0
-      vite: 5.1.0(less@4.2.0)
+      vite: 5.1.0(less@4.2.0)(sass@1.70.0)
     dev: true
 
-  /vite@5.1.0(less@4.2.0):
+  /vite@5.1.0(less@4.2.0)(sass@1.70.0):
     resolution: {integrity: sha512-STmSFzhY4ljuhz14bg9LkMTk3d98IO6DIArnTY6MeBwiD1Za2StcQtz7fzOUnRCqrHSD5+OS2reg4HOz1eoLnw==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
@@ -1261,6 +1262,7 @@ packages:
       less: 4.2.0
       postcss: 8.4.35
       rollup: 4.9.6
+      sass: 1.70.0
     optionalDependencies:
       fsevents: 2.3.3
 

--- a/src/Sources/LightPortal/Areas/CreditArea.php
+++ b/src/Sources/LightPortal/Areas/CreditArea.php
@@ -256,15 +256,6 @@ final class CreditArea
 				]
 			],
 			[
-				'title' => 'Less.php',
-				'link' => 'https://github.com/wikimedia/less.php',
-				'author' => 'Wikimedia Foundation',
-				'license' => [
-					'name' => 'the Apache License 2.0',
-					'link' => 'https://github.com/wikimedia/less.php/blob/master/LICENSE'
-				]
-			],
-			[
 				'title' => 'Sortable.js',
 				'link' => 'https://github.com/SortableJS/Sortable',
 				'author' => 'All contributors to Sortable',

--- a/src/Sources/LightPortal/Compilers/AbstractCompiler.php
+++ b/src/Sources/LightPortal/Compilers/AbstractCompiler.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types=1);
+
+/**
+ * AbstractCompiler.php
+ *
+ * @package Light Portal
+ * @link https://dragomano.ru/mods/light-portal
+ * @author Bugo <bugo@dragomano.ru>
+ * @copyright 2019-2024 Bugo
+ * @license https://spdx.org/licenses/GPL-3.0-or-later.html GPL-3.0-or-later
+ *
+ * @version 2.5
+ */
+
+namespace Bugo\LightPortal\Compilers;
+
+use Bugo\Compat\Theme;
+use Bugo\LightPortal\Helper;
+
+abstract class AbstractCompiler implements CompilerInterface
+{
+	use Helper;
+
+	public function __construct()
+	{
+		$this->applyHook('clean_cache');
+	}
+
+	protected function getCssDirPath(): string
+	{
+		return Theme::$current->settings['default_theme_dir'] . '/css/light_portal';
+	}
+}

--- a/src/Sources/LightPortal/Compilers/CompilerInterface.php
+++ b/src/Sources/LightPortal/Compilers/CompilerInterface.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types=1);
+
+/**
+ * CompilerInterface.php
+ *
+ * @package Light Portal
+ * @link https://dragomano.ru/mods/light-portal
+ * @author Bugo <bugo@dragomano.ru>
+ * @copyright 2019-2024 Bugo
+ * @license https://spdx.org/licenses/GPL-3.0-or-later.html GPL-3.0-or-later
+ *
+ * @version 2.5
+ */
+
+namespace Bugo\LightPortal\Compilers;
+
+interface CompilerInterface
+{
+	public function compile(): void;
+
+	public function cleanCache(): void;
+}

--- a/src/Sources/LightPortal/Compilers/Less.php
+++ b/src/Sources/LightPortal/Compilers/Less.php
@@ -1,0 +1,59 @@
+<?php declare(strict_types=1);
+
+/**
+ * Less.php
+ *
+ * @package Light Portal
+ * @link https://dragomano.ru/mods/light-portal
+ * @author Bugo <bugo@dragomano.ru>
+ * @copyright 2019-2024 Bugo
+ * @license https://spdx.org/licenses/GPL-3.0-or-later.html GPL-3.0-or-later
+ *
+ * @version 2.5
+ */
+
+namespace Bugo\LightPortal\Compilers;
+
+use Bugo\Compat\Config;
+use Bugo\Compat\ErrorHandler;
+use Bugo\Compat\Sapi;
+use Exception;
+use Less_Exception_Parser;
+use Less_Parser;
+
+class Less extends AbstractCompiler
+{
+	public function compile(): void
+	{
+		$cssFile  = $this->getCssDirPath() . '/portal.css';
+		$lessFile = $this->getCssDirPath() . '/less/portal.less';
+
+		if (! is_file($lessFile))
+			return;
+
+		if (is_file($cssFile) && filemtime($lessFile) < filemtime($cssFile))
+			return;
+
+		try {
+			$parser = new Less_Parser([
+				'compress'  => true,
+				'cache_dir' => empty(Config::$modSettings['cache_enable']) ? null : Sapi::getTempDir(),
+			]);
+
+			$parser->parseFile($lessFile);
+
+			file_put_contents($cssFile, $parser->getCss());
+		} catch (Less_Exception_Parser | Exception $e) {
+			ErrorHandler::log($e->getMessage(), 'critical');
+		}
+	}
+
+	public function cleanCache(): void
+	{
+		$file = $this->getCssDirPath() . '/less/portal.less';
+
+		if (is_file($file)) {
+			touch($file);
+		}
+	}
+}

--- a/src/Sources/LightPortal/Compilers/Sass.php
+++ b/src/Sources/LightPortal/Compilers/Sass.php
@@ -1,0 +1,61 @@
+<?php declare(strict_types=1);
+
+/**
+ * Sass.php
+ *
+ * @package Light Portal
+ * @link https://dragomano.ru/mods/light-portal
+ * @author Bugo <bugo@dragomano.ru>
+ * @copyright 2019-2024 Bugo
+ * @license https://spdx.org/licenses/GPL-3.0-or-later.html GPL-3.0-or-later
+ *
+ * @version 2.5
+ */
+
+namespace Bugo\LightPortal\Compilers;
+
+use Bugo\Compat\Config;
+use Bugo\Compat\ErrorHandler;
+use Bugo\Compat\Sapi;
+use Exception;
+use ScssPhp\ScssPhp\Compiler;
+use ScssPhp\ScssPhp\Exception\SassException;
+use ScssPhp\ScssPhp\OutputStyle;
+
+class Sass extends AbstractCompiler
+{
+	public function compile(): void
+	{
+		$cssFile  = $this->getCssDirPath() . '/portal.css';
+		$scssFile = $this->getCssDirPath() . '/sass/portal.scss';
+
+		if (! is_file($scssFile))
+			return;
+
+		if (is_file($cssFile) && filemtime($scssFile) < filemtime($cssFile))
+			return;
+
+		try {
+			$compiler = new Compiler([
+				'cacheDir' => empty(Config::$modSettings['cache_enable']) ? null : Sapi::getTempDir(),
+			]);
+
+			$compiler->setOutputStyle(OutputStyle::COMPRESSED);
+
+			$result = $compiler->compileFile($scssFile);
+
+			file_put_contents($cssFile, $result->getCss());
+		} catch (SassException | Exception $e) {
+			ErrorHandler::log($e->getMessage(), 'critical');
+		}
+	}
+
+	public function cleanCache(): void
+	{
+		$file = $this->getCssDirPath() . '/sass/portal.scss';
+
+		if (is_file($file)) {
+			touch($file);
+		}
+	}
+}

--- a/src/Sources/LightPortal/Compilers/Zero.php
+++ b/src/Sources/LightPortal/Compilers/Zero.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types=1);
+
+/**
+ * Zero.php
+ *
+ * @package Light Portal
+ * @link https://dragomano.ru/mods/light-portal
+ * @author Bugo <bugo@dragomano.ru>
+ * @copyright 2019-2024 Bugo
+ * @license https://spdx.org/licenses/GPL-3.0-or-later.html GPL-3.0-or-later
+ *
+ * @version 2.5
+ */
+
+namespace Bugo\LightPortal\Compilers;
+
+class Zero extends AbstractCompiler
+{
+	public function compile(): void
+	{
+	}
+
+	public function cleanCache(): void
+	{
+	}
+}

--- a/src/Sources/LightPortal/Compilers/index.php
+++ b/src/Sources/LightPortal/Compilers/index.php
@@ -1,0 +1,6 @@
+<?php
+
+if (file_exists(dirname(__DIR__) . '/index.php'))
+	include (dirname(__DIR__) . '/index.php');
+else
+	exit;

--- a/src/Sources/LightPortal/Integration.php
+++ b/src/Sources/LightPortal/Integration.php
@@ -14,10 +14,10 @@
 
 namespace Bugo\LightPortal;
 
-use Bugo\Compat\{Config, Database as Db, Lang, Theme, User, Utils};
+use Bugo\LightPortal\Compilers\Zero;
+use Bugo\Compat\{Config, Database as Db, Lang, User, Utils};
 use Bugo\LightPortal\Actions\{BoardIndex, Block, Category};
 use Bugo\LightPortal\Actions\{FrontPage, Page, Tag};
-use Bugo\LightPortal\Areas\{ConfigArea, CreditArea};
 
 if (! defined('SMF'))
 	die('No direct access...');
@@ -27,12 +27,6 @@ if (! defined('SMF'))
  */
 final class Integration extends AbstractMain
 {
-	public function __construct()
-	{
-		(new ConfigArea())();
-		(new CreditArea())();
-	}
-
 	public function __invoke(): void
 	{
 		$this->applyHook('init');
@@ -55,7 +49,6 @@ final class Integration extends AbstractMain
 		$this->applyHook('profile_popup');
 		$this->applyHook('download_request');
 		$this->applyHook('whos_online');
-		$this->applyHook('clean_cache');
 	}
 
 	public function init(): void
@@ -131,7 +124,8 @@ final class Integration extends AbstractMain
 		Lang::load('LightPortal/LightPortal');
 
 		$this->defineVars();
-		$this->loadAssets();
+
+		$this->loadAssets(new Zero());
 
 		$this->hook('init');
 	}
@@ -545,14 +539,5 @@ final class Integration extends AbstractMain
 		}
 
 		return $result;
-	}
-
-	public function cleanCache(): void
-	{
-		$file = Theme::$current->settings['default_theme_dir'] . '/css/light_portal/less/portal.less';
-
-		if (is_file($file)) {
-			touch($file);
-		}
 	}
 }

--- a/src/Sources/LightPortal/Tests/IntegrationTest.php
+++ b/src/Sources/LightPortal/Tests/IntegrationTest.php
@@ -31,7 +31,6 @@ test('hook methods exist', function () {
 	Assert::true(method_exists(Integration::class, 'profileAreas'));
 	Assert::true(method_exists(Integration::class, 'profilePopup'));
 	Assert::true(method_exists(Integration::class, 'whosOnline'));
-	Assert::true(method_exists(Integration::class, 'cleanCache'));
 });
 
 test('init method', function () {

--- a/src/Sources/LightPortal/app.php
+++ b/src/Sources/LightPortal/app.php
@@ -37,5 +37,10 @@ if (str_starts_with(SMF_VERSION, '3.0')) {
 	array_map($applyAlias, array_keys($aliases), $aliases);
 }
 
+// Development mode
+if (is_file(__DIR__ . '/Libs/scssphp/scssphp/src/Compiler.php'))
+	/** @noinspection PhpIgnoredClassAliasDeclaration */
+	class_alias('Bugo\\LightPortal\\Compilers\\Sass', 'Bugo\\LightPortal\\Compilers\\Zero');
+
 // This is the way
 (new Integration())();

--- a/src/Sources/LightPortal/composer.json
+++ b/src/Sources/LightPortal/composer.json
@@ -7,12 +7,13 @@
     "ext-zip": "*",
     "bugo/smf-compat": "^0.1.4",
     "laminas/laminas-loader": "^2.9",
-    "latte/latte": "^3.0",
-    "wikimedia/less.php": "^4.1"
+    "latte/latte": "^3.0"
   },
   "require-dev": {
     "mockery/mockery": "^1.5",
-    "nette/tester": "^2.5"
+    "nette/tester": "^2.5",
+    "scssphp/scssphp": "^1.12",
+    "wikimedia/less.php": "^4.1"
   },
   "autoload-dev": {
     "psr-4": {

--- a/src/Themes/default/css/light_portal/sass/_functions.scss
+++ b/src/Themes/default/css/light_portal/sass/_functions.scss
@@ -1,0 +1,26 @@
+@mixin pointer() {
+	cursor: pointer;
+}
+
+@mixin valign($align: middle) {
+	vertical-align: $align;
+}
+
+@mixin bradius($topleft: 6px, $topright: null, $bottomright: null, $bottomleft: null) {
+	@if $topright == null and $bottomright == null and $bottomleft == null {
+		border-radius: $topleft;
+		$topleft: null;
+	}
+	@if $topleft != null and $topleft >= 0 {
+		border-top-left-radius: $topleft;
+	}
+	@if $topright != null and $topright >= 0 {
+		border-top-right-radius: $topright;
+	}
+	@if $bottomleft != null and $bottomleft >= 0 {
+		border-bottom-left-radius: $bottomleft;
+	}
+	@if $bottomright != null and $bottomright >= 0 {
+		border-bottom-right-radius: $bottomright;
+	}
+}

--- a/src/Themes/default/css/light_portal/sass/_variables.scss
+++ b/src/Themes/default/css/light_portal/sass/_variables.scss
@@ -1,0 +1,16 @@
+$color-light-gray: #ddd;
+$color-white: #fff;
+$color-black: #000;
+$color-checked: #00cc33;
+$article-category-color: #868686;
+$article-author-color: #ad7d52;
+$comment-smalltext-color: #bfbfbf;
+$tabs-input-color: #555;
+$tabs-input-border-color: #f49a3a;
+$tabs-label-color: #aaa;
+$tabs-label-hover-color: #888;
+
+$tag-bg-color: #f2f2f2;
+$tag-border-color: #d0d0d0;
+$tag-color: #303030;
+$ignore-action: greenyellow;

--- a/src/Themes/default/css/light_portal/sass/admin_blocks.scss
+++ b/src/Themes/default/css/light_portal/sass/admin_blocks.scss
@@ -1,0 +1,7 @@
+.preview_frame {
+	margin: 10px;
+	padding: 10px;
+	border: thick double #32a1ce;
+	border-radius: 6px;
+	overflow: auto;
+}

--- a/src/Themes/default/css/light_portal/sass/admin_categories.scss
+++ b/src/Themes/default/css/light_portal/sass/admin_categories.scss
@@ -1,0 +1,25 @@
+.lp_categories {
+	input {
+		width: 100%;
+	}
+	textarea {
+		width: 100%;
+		resize: none;
+		margin-top: 1px;
+	}
+	dt {
+		td.handle {
+			font-size: 1.2rem;
+		}
+		span.floatright {
+			@include pointer;
+			font-size: 1.4rem;
+			font-weight: bold;
+		}
+	}
+	dd {
+		.roundframe {
+			margin-top: 0;
+		}
+	}
+}

--- a/src/Themes/default/css/light_portal/sass/admin_checkbox.scss
+++ b/src/Themes/default/css/light_portal/sass/admin_checkbox.scss
@@ -1,0 +1,57 @@
+.checkbox {
+	@include valign(top);
+	margin: 0 3px 0 0;
+	width: 17px;
+	height: 17px;
+
+	& + .label {
+		@include pointer;
+	}
+
+	&:not(checked) {
+		position: absolute;
+		opacity: 0;
+
+		& + .label {
+			position: relative;
+			padding: 0 0 0 60px;
+
+			&::before {
+				content: '';
+				position: absolute;
+				top: -4px;
+				left: 0;
+				width: 50px;
+				height: 26px;
+				@include bradius(13px);
+				background: #cdd1da;
+				box-shadow: inset 0 2px 3px rgba(0, 0, 0, .2);
+			}
+
+			&::after {
+				content: '';
+				position: absolute;
+				top: -2px;
+				left: 2px;
+				width: 22px;
+				height: 22px;
+				@include bradius(10px);
+				background: $color-white;
+				box-shadow: 0 2px 5px rgba(0, 0, 0, .3);
+				transition: all .2s;
+			}
+		}
+	}
+
+	&:checked {
+		& + .label {
+			&::before {
+				background: $color-checked;
+			}
+
+			&::after {
+				left: 26px;
+			}
+		}
+	}
+}

--- a/src/Themes/default/css/light_portal/sass/admin_context.scss
+++ b/src/Themes/default/css/light_portal/sass/admin_context.scss
@@ -1,0 +1,24 @@
+.actions {
+	.context_menu {
+		position: relative;
+
+		.roundframe {
+			position: absolute;
+			top: 0;
+			right: 0;
+			z-index: 30;
+
+			ul {
+				overflow: auto;
+				position: relative;
+				list-style: none;
+				z-index: 10;
+
+				a {
+					width: 100%;
+					margin-bottom: 2px;
+				}
+			}
+		}
+	}
+}

--- a/src/Themes/default/css/light_portal/sass/admin_pages.scss
+++ b/src/Themes/default/css/light_portal/sass/admin_pages.scss
@@ -1,0 +1,22 @@
+#lp_pages {
+	th,
+	td {
+		@media (max-width: 480px) {
+			&.date {
+				display: none;
+			}
+		}
+
+		@media (max-width: 800px) {
+			&.num_views {
+				display: none;
+			}
+		}
+
+		@media (max-width: 887px) {
+			&.alias {
+				display: none;
+			}
+		}
+	}
+}

--- a/src/Themes/default/css/light_portal/sass/admin_plugins.scss
+++ b/src/Themes/default/css/light_portal/sass/admin_plugins.scss
@@ -1,0 +1,230 @@
+#vue_plugins {
+	.fade-enter-active,
+	.fade-move {
+		transition: 0.4s ease all;
+	}
+
+	.fade-enter-from,
+	.fade-leave-to {
+		opacity: 0;
+		transform: scale(0.6);
+	}
+
+	.fade-leave-active {
+		transition: 0.4s ease all;
+		position: absolute;
+	}
+
+	.fade-list-enter-active,
+	.fade-list-leave-active {
+		transition: 0.4s ease all;
+	}
+
+	.fade-list-enter-from,
+	.fade-list-leave-to {
+		transform: translateY(10px);
+		opacity: 0;
+	}
+
+	.information {
+		[role='button'] {
+			opacity: 0.6;
+
+			&:hover {
+				opacity: 1;
+				@include pointer;
+			}
+		}
+	}
+
+	#filter {
+		margin-left: 4px;
+		cursor: pointer;
+	}
+
+	@media screen and (max-width: 468px) {
+		label[for="filter"] {
+			display: none;
+		}
+	}
+}
+
+
+#addon_list {
+	.windowbg {
+		box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1) !important;
+	}
+}
+
+.addon_list {
+	display: grid;
+	grid-template-columns: auto auto;
+	grid-column-gap: 10px;
+
+	.windowbg {
+		&:only-child {
+			grid-column-start: 1;
+			grid-column-end: -1;
+		}
+	}
+
+	@media screen and (max-width: 468px) {
+		grid-template-columns: auto;
+	}
+}
+
+.features {
+	.floatleft {
+		width: 80%;
+
+		.new_posts {
+			margin: 2px;
+		}
+	}
+
+	.floatright {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		gap: 6px;
+		@include pointer;
+
+		span {
+			&[data-toggle="on"] {
+				color: $color-checked;
+			}
+		}
+	}
+
+	form {
+		div[is]:has(input[type='text']:focus) {
+			border: 1px solid var(--toggle-border-on, #10b981);
+		}
+
+		textarea {
+			width: 100%;
+		}
+	}
+
+	.fade-enter-active,
+	.fade-leave-active {
+		transition: all 0.5s ease;
+	}
+
+	.fade-enter-from,
+	.fade-leave-to {
+		opacity: 0;
+		transform: scale(0.5);
+	}
+}
+
+.form_settings {
+	> div {
+		margin: 1em;
+	}
+
+	label {
+		font-weight: bold;
+		color: initial;
+	}
+
+	input {
+		height: 28px;
+
+		&[type='text'],
+		&[type='url'] {
+			width: 100%;
+		}
+
+		&[type='number'] {
+			width: 15%;
+
+			& {
+				@media screen and (max-width: 600px) {
+					width: 100%;
+				}
+			}
+		}
+	}
+
+	.multiselect-tags-search {
+		box-shadow: none;
+		height: auto !important;
+		line-height: unset;
+	}
+
+	.checkbox_field {
+		padding-top: 0.8em;
+
+		.toggle-label {
+			position: absolute;
+			text-align: left;
+			left: 60px;
+			cursor: pointer;
+			color: initial;
+			font-size: 1.2em;
+			width: #{"max(8vw, 200px)"};
+			white-space: pre-line;
+		}
+	}
+
+	.postfix {
+		margin-left: 4px;
+	}
+
+	.range_field {
+		margin-left: 6px;
+		font-weight: bold;
+	}
+
+	textarea {
+		width: 100%;
+		resize: none;
+	}
+}
+
+.footer {
+	.infobox {
+		opacity: 0;
+		height: 25px;
+		margin-bottom: 0;
+		width: auto;
+		transition: opacity 3s ease-in-out;
+
+		&.show {
+			opacity: 1;
+		}
+	}
+
+	.button {
+		margin-left: 2px;
+
+		&[disabled] {
+			opacity: 0.5;
+			cursor: not-allowed;
+		}
+	}
+
+	@media screen and (max-width: 500px) {
+		display: grid;
+		gap: 4px;
+	}
+}
+
+#addon_chart {
+	margin-bottom: 1em;
+}
+
+
+[dir='rtl'] {
+	.checkbox_field {
+		.toggle-label {
+			text-align: right;
+			right: 60px;
+		}
+	}
+}
+
+.windowbg:has(.features .floatright span.fa-spin) {
+	border: 2px solid var(--toggle-border-on, #10b981);
+}

--- a/src/Themes/default/css/light_portal/sass/admin_settings.scss
+++ b/src/Themes/default/css/light_portal/sass/admin_settings.scss
@@ -1,0 +1,28 @@
+
+dl.settings {
+	div {
+		dt, dd {
+			width: 50%;
+
+			@media (max-width: 600px) {
+				width: 100%;
+			}
+		}
+	}
+}
+
+.lp_table_settings {
+	width: 100%;
+
+	td {
+		width: 50%;
+	}
+
+	@media (max-width: 600px) {
+		td {
+			display: block;
+			padding: 5px 0;
+			width: 100%;
+		}
+	}
+}

--- a/src/Themes/default/css/light_portal/sass/admin_tabs.scss
+++ b/src/Themes/default/css/light_portal/sass/admin_tabs.scss
@@ -1,0 +1,171 @@
+.lp_tabs {
+	padding: 0;
+	margin: 0 auto;
+
+	input,
+	textarea {
+		&:invalid {
+			border: 3px double red;
+		}
+	}
+
+	div[data-navigation] {
+		@media screen and (min-width: 401px) and (max-width: 790px) {
+			display: grid;
+			grid-template-columns: repeat(2, 1fr);
+			grid-auto-rows: minmax(10px, auto);
+		}
+
+		> div {
+			@include bradius(6px, 6px);
+			display: inline-block;
+			margin: 0 0 -1px;
+			padding: 15px 25px;
+			font-weight: 600;
+			text-align: center;
+			color: $tabs-label-color;
+			border: 1px solid $color-light-gray;
+
+			&.active_navigation {
+				color: $tabs-input-color !important;
+				border-top: 1px solid $tabs-input-border-color !important;
+				border-bottom: 1px solid $color-white !important;
+			}
+
+			&:hover {
+				@include pointer;
+				color: $tabs-label-hover-color;
+			}
+
+			i,
+			svg {
+				font-size: 1.2em !important;
+			}
+
+			@media screen and (max-width: 680px) {
+				i,
+				svg {
+					font-size: 1.6em !important;
+				}
+			}
+
+			@media screen and (max-width: 400px) {
+				padding: 15px;
+				display: grid;
+				grid-auto-flow: column;
+				justify-content: space-between;
+			}
+		}
+	}
+
+	section {
+		display: none;
+		padding: 15px;
+		border: 1px solid $color-light-gray;
+		@include bradius(0, 7px, 7px, 7px);
+
+		&.active_content {
+			display: block;
+		}
+
+		> div {
+			margin-top: 1em;
+		}
+
+		#post_header {
+			display: flex;
+			flex-wrap: wrap;
+			flex-direction: column;
+			line-height: 1.5;
+			-webkit-animation-duration: 1s;
+			animation-duration: 1s;
+			-webkit-animation-fill-mode: both;
+			animation-fill-mode: both;
+			-webkit-animation-name: fadeIn;
+			animation-name: fadeIn;
+
+			@media (max-width: 600px) {
+				flex-direction: row;
+			}
+
+			dt {
+				width: 50%;
+
+				label {
+					font-weight: bold;
+				}
+			}
+
+			dt,
+			dd {
+				margin-block-end: 5px;
+				margin-inline-start: 0;
+				padding-top: 5px;
+
+				&:first-child {
+					margin-block-start: 0;
+				}
+
+				&:last-child {
+					margin-block-end: 0;
+				}
+
+				& > *:first-child {
+					margin-block-start: 0;
+				}
+				& > *:last-child {
+					margin-block-end: 0;
+				}
+
+				width: auto !important;
+				float: none !important;
+				flex: 2 50%;
+
+				@media (max-width: 600px) {
+					flex: 1 100%;
+					text-align: center;
+				}
+
+				input[type="text"] {
+					width: 100%;
+					margin-top: 4px;
+					padding: 20px 10px;
+					font-size: 1.2em;
+					box-shadow: 0 1px 3px #575555 inset;
+
+					&:focus {
+						border: 1px solid var(--toggle-border-on, #10b981);
+					}
+				}
+			}
+
+			dt.pf_content,
+			dd.pf_content {
+				width: 100%;
+
+				@media (max-width: 600px) {
+					text-align: justify;
+				}
+			}
+		}
+
+		.choices__inner {
+			@include bradius;
+		}
+
+		.add_option {
+			width: 100%;
+
+			select,
+			input {
+				width: 100%;
+			}
+
+			@media screen and (max-width: 680px) {
+				.plugin_options td:first-child {
+					display: none;
+				}
+			}
+		}
+	}
+}

--- a/src/Themes/default/css/light_portal/sass/badges.scss
+++ b/src/Themes/default/css/light_portal/sass/badges.scss
@@ -1,0 +1,45 @@
+.new_posts {
+	$block_color: #667d99;
+	$editor_color: #48bf83;
+	$comment_color: #9354ca;
+	$article_color: #ef564f;
+	&.lp_type_block {
+		background: $block_color;
+	}
+	&.lp_type_editor {
+		background: $editor_color;
+	}
+	&.lp_type_comment {
+		background: $comment_color;
+	}
+	&.lp_type_parser {
+		background: #91ae26;
+	}
+	&.lp_type_article {
+		background: $article_color;
+	}
+	&.lp_type_frontpage {
+		background: #d68b4f;
+	}
+	&.lp_type_impex {
+		background:#2361ad;
+	}
+	&.lp_type_block_options {
+		background: lighten($comment_color, 10%);
+	}
+	&.lp_type_page_options {
+		background: #a39d47;
+	}
+	&.lp_type_icons {
+		background: darken($editor_color, 20%);
+	}
+	&.lp_type_seo {
+		background: darken($article_color, 20%);
+	}
+	&.lp_type_other {
+		background: #414141;
+	}
+	&.lp_type_ssi {
+		background: darken($comment_color, 20%);
+	}
+}

--- a/src/Themes/default/css/light_portal/sass/blocks.scss
+++ b/src/Themes/default/css/light_portal/sass/blocks.scss
@@ -1,0 +1,26 @@
+#lp_blocks {
+	.item {
+		@include pointer;
+		height: 96%;
+		transition: all .2s;
+		text-align: center;
+		overflow: hidden;
+
+		&:hover {
+			box-shadow: 0 2px 5px rgba(0, 0, 0, .3);
+		}
+
+		div {
+			font-size: 16px;
+			margin: 10px;
+		}
+
+		p {
+			text-align: left;
+			font-size: 14px;
+			line-height: 21px;
+		}
+	}
+
+	margin-bottom: 1em;
+}

--- a/src/Themes/default/css/light_portal/sass/frontpage_alt.scss
+++ b/src/Themes/default/css/light_portal/sass/frontpage_alt.scss
@@ -1,0 +1,49 @@
+.article_alt_view {
+	article {
+		transition: all .4s cubic-bezier(.175, .885, 0, 1);
+		position: relative;
+		padding: 1em;
+		display: flex;
+		flex-direction: column;
+		justify-content: space-between;
+		height: 99%;
+
+		header {
+			.title_bar {
+				padding: 8px 12px;
+
+				h3 {
+					white-space: nowrap;
+					overflow: hidden;
+					text-overflow: ellipsis;
+				}
+
+				+ div {
+					padding: 10px;
+				}
+			}
+
+			img {
+				max-height: 235px;
+				width: 100%;
+			}
+		}
+
+		.article_body {
+			p {
+				margin-bottom: 5px;
+				overflow: hidden;
+				display: -webkit-box;
+				-webkit-line-clamp: 3;
+				-webkit-box-orient: vertical;
+				line-height: 1.4em;
+			}
+		}
+
+		.article_footer {
+			div {
+				padding: 4px;
+			}
+		}
+	}
+}

--- a/src/Themes/default/css/light_portal/sass/frontpage_alt2.scss
+++ b/src/Themes/default/css/light_portal/sass/frontpage_alt2.scss
@@ -1,0 +1,93 @@
+.article_alt2_view {
+	display: flex;
+	flex-wrap: wrap;
+
+	article {
+		display: flex;
+		flex: 1 1 300px;
+		flex-direction: column;
+		overflow: hidden;
+		margin: 0 10px 10px;
+		min-height: 300px;
+		background-size: cover;
+		@include bradius;
+		box-shadow: 0 3px 7px -1px rgba(0, 0, 0, .1);
+		transition: all .5s ease;
+
+		.article_image_link {
+			display: block;
+			position: relative;
+			overflow: hidden;
+			@include bradius(5px, 5px);
+
+			div {
+				width: auto;
+				height: 200px;
+				background-repeat: no-repeat;
+				background-size: cover;
+			}
+		}
+
+		.article_body {
+			display: flex;
+			flex-grow: 1;
+			flex-direction: column;
+			justify-content: space-between;
+
+			div {
+				display: block;
+				position: relative;
+				padding: 25px 25px 0;
+
+				header {
+					time {
+						display: block;
+						margin-bottom: 4px;
+						line-height: 1.15;
+						font-weight: 500;
+						letter-spacing: .5px;
+						text-transform: uppercase;
+					}
+
+					h3 {
+						margin: 1em 0 .5em;
+						font-size: 1.2rem;
+						line-height: 1.15;
+					}
+				}
+
+				section {
+					p {
+						margin-bottom: 5px;
+						overflow: hidden;
+						display: -webkit-box;
+						-webkit-line-clamp: 3;
+						-webkit-box-orient: vertical;
+						line-height: 1.4em;
+					}
+				}
+			}
+
+			footer {
+				display: flex;
+				justify-content: space-between;
+				align-items: flex-end;
+				padding: 0 25px 5px;
+
+				img, svg {
+					margin-right: 5px;
+					width: 25px;
+					height: 25px;
+					@include bradius(100%);
+					object-fit: cover;
+				}
+
+				> span {
+					font-weight: 500;
+					letter-spacing: .5px;
+					text-transform: uppercase;
+				}
+			}
+		}
+	}
+}

--- a/src/Themes/default/css/light_portal/sass/frontpage_alt3.scss
+++ b/src/Themes/default/css/light_portal/sass/frontpage_alt3.scss
@@ -1,0 +1,191 @@
+.article_alt3_view {
+	.card {
+		display: flex;
+		flex-direction: column;
+		margin: 1rem auto;
+		box-shadow: 0 3px 7px -1px rgba(0, 0, 0, .1);
+		line-height: 1.4;
+		font-family: sans-serif;
+		@include bradius;
+		overflow: hidden;
+		z-index: 0;
+
+		&:hover {
+			.photo {
+				transform: scale(1.3) rotate(3deg);
+			}
+
+			.details {
+				left: 0%;
+			}
+		}
+
+		a {
+			color: inherit;
+		}
+
+		.meta {
+			position: relative;
+			z-index: 0;
+			height: 200px;
+		}
+
+		.photo {
+			position: absolute;
+			top: 0;
+			right: 0;
+			bottom: 0;
+			left: 0;
+			background-size: cover;
+			background-position: center;
+			transition: transform .2s;
+		}
+
+		.details {
+			margin: auto;
+			list-style: none;
+			position: absolute;
+			top: 0;
+			bottom: 0;
+			left: -100%;
+			margin: auto;
+			transition: left .2s;
+			background: rgba(0, 0, 0, .6);
+			color: $color-white;
+			padding: 10px;
+			width: 100%;
+			font-size: .9rem;
+
+			strong {
+				color: inherit;
+			}
+
+			ul {
+				margin: auto;
+				padding: 0;
+				list-style: none;
+
+				li {
+					display: inline-block;
+				}
+			}
+
+			i {
+				margin-right: 10px;
+			}
+
+			a {
+				-webkit-text-decoration: dotted underline;
+						text-decoration: dotted underline;
+
+				&:hover {
+					color: #5ad67d;
+				}
+			}
+
+			.tags {
+				li {
+					margin-right: 2px;
+
+					&:first-child {
+						margin-left: -4px;
+					}
+				}
+			}
+		}
+
+		.description {
+			padding: 1rem;
+			background: $color-white;
+			position: relative;
+			z-index: 1;
+			display: flex;
+			justify-content: space-between;
+			flex-direction: column;
+
+			a {
+				&:hover {
+					text-decoration: none;
+				}
+			}
+
+			h1,
+			h2 {
+				font-family: Poppins, sans-serif;
+			}
+
+			h1 {
+				line-height: 1;
+				margin: 0;
+				font-size: 1.4rem;
+			}
+
+			h2 {
+				font-weight: 300;
+				text-transform: uppercase;
+				color: #a2a2a2;
+				margin-top: 5px;
+			}
+
+			p {
+				position: relative;
+				margin: 1rem 0 0;
+				margin-bottom: 5px;
+				overflow: hidden;
+				//text-overflow: ellipsis;
+				display: -webkit-box;
+				-webkit-line-clamp: 3;
+				-webkit-box-orient: vertical;
+				line-height: 1.4em;
+
+				&:first-of-type {
+					margin-top: 1.25rem;
+
+					&::before {
+						content: "";
+						position: absolute;
+						height: 5px;
+						background: #5ad67d;
+						width: 35px;
+						top: -.75rem;
+						@include bradius(3px);
+					}
+				}
+			}
+
+			.read_more {
+				text-align: right;
+
+				a {
+					display: inline-block;
+					position: relative;
+				}
+			}
+		}
+
+		@media (min-width: 640px) {
+			flex-direction: row;
+
+			.meta {
+				flex-basis: 40%;
+				height: auto;
+			}
+
+			.description {
+				flex-basis: 60%;
+
+				&::before {
+					transform: skewX(-3deg);
+					content: "";
+					background: $color-white;
+					width: 30px;
+					position: absolute;
+					left: -10px;
+					top: 0;
+					bottom: -1px;
+					z-index: -1;
+				}
+			}
+		}
+	}
+}

--- a/src/Themes/default/css/light_portal/sass/frontpage_default.scss
+++ b/src/Themes/default/css/light_portal/sass/frontpage_default.scss
@@ -1,0 +1,153 @@
+.lp_frontpage_articles {
+	display: flex;
+	flex-direction: row;
+	flex-wrap: wrap;
+}
+
+.article_view {
+	> div {
+		margin-bottom: 10px;
+	}
+
+	article {
+		@include bradius(12px);
+		transition: all .4s cubic-bezier(.175, .885, 0, 1);
+		position: relative;
+		overflow: hidden;
+		padding: 0;
+		display: flex;
+		flex-direction: column;
+		justify-content: flex-end;
+		height: 95%;
+		min-height: 100%;
+
+		a:hover {
+			text-decoration: none;
+			opacity: .7;
+		}
+
+		.new_posts {
+			margin-left: 4px;
+		}
+
+		&:hover {
+			box-shadow: 0 0 10px 5px rgba(221, 221, 221, 1);
+
+			.new_posts {
+				display: none;
+			}
+
+			.new_hover,
+			.info_hover {
+				opacity: 1;
+				z-index: 1;
+			}
+
+			.card_img_hover {
+				opacity: .5;
+			}
+
+			.card_info {
+				background-color: transparent;
+				position: relative;
+			}
+		}
+
+		.new_hover {
+			position: absolute;
+			padding: 16px;
+			top: 0;
+			left: 0;
+
+			.new_icon {
+				position: relative;
+				z-index: 2;
+			}
+		}
+
+		.info_hover {
+			position: absolute;
+			padding: 16px;
+			opacity: 0;
+			top: 0;
+			right: 0;
+
+			.edit_icon {
+				position: relative;
+				z-index: 2;
+			}
+		}
+
+		.card_img {
+			visibility: hidden;
+			background-size: cover;
+			background-position: center;
+			background-repeat: no-repeat;
+			width: 100%;
+			height: 235px;
+		}
+
+		.card_img_hover {
+			transition: .2s all ease-out;
+			background-size: cover;
+			background-position: center;
+			background-repeat: no-repeat;
+			width: 100%;
+			position: absolute;
+			height: 235px;
+			top: 0;
+		}
+
+		.card_info {
+			display: flex;
+			flex-grow: 1;
+			flex-direction: column;
+			justify-content: space-between;
+			padding: 1.2em;
+
+			div {
+				margin-top: 1em;
+			}
+
+			.card_date {
+				font-weight: 500;
+				color: $article-category-color;
+			}
+
+			h3 {
+				font-size: 1.25rem;
+				font-weight: 700;
+				margin: 10px 0 10px 0;
+				overflow: hidden;
+				display: -webkit-box;
+				-webkit-line-clamp: 2;
+				-webkit-box-orient: vertical;
+				line-height: 1.3em;
+				text-wrap: balance;
+
+				+ div {
+					display: flex;
+					flex-wrap: wrap;
+					flex-direction: row;
+					justify-content: space-between;
+				}
+			}
+
+			p {
+				margin-bottom: 5px;
+				overflow: hidden;
+				//text-overflow: ellipsis;
+				display: -webkit-box;
+				-webkit-line-clamp: 3;
+				-webkit-box-orient: vertical;
+				line-height: 1.4em;
+			}
+
+			.card_author {
+				font-weight: 600;
+				text-decoration: none;
+				color: $article-author-color;
+			}
+		}
+	}
+}

--- a/src/Themes/default/css/light_portal/sass/frontpage_flarum.scss
+++ b/src/Themes/default/css/light_portal/sass/frontpage_flarum.scss
@@ -1,0 +1,30 @@
+.article_flarum_view {
+	.title_bar {
+		margin-bottom: 1em;
+	}
+
+	.header_img {
+		display: grid;
+		place-content: center;
+	}
+
+	.header_area {
+		display: block;
+		margin-left: 20px;
+		width: 70%;
+		text-decoration: none;
+
+		h3 {
+			margin: 0 0 3px;
+			line-height: 1.3;
+			font-weight: 400;
+			font-size: 16px;
+			overflow: hidden;
+			text-overflow: ellipsis;
+		}
+
+		.smalltext {
+			opacity: .5;
+		}
+	}
+}

--- a/src/Themes/default/css/light_portal/sass/frontpage_simple.scss
+++ b/src/Themes/default/css/light_portal/sass/frontpage_simple.scss
@@ -1,0 +1,44 @@
+.article_simple_view {
+	> div {
+		padding: .75rem;
+		@include bradius(.25rem);
+		display: flex;
+		flex-grow: 1;
+		flex-direction: column;
+		justify-content: space-between;
+
+		&:hover {
+			box-shadow: 0 1px 3px 0 rgba(0, 0, 0, .1), 0 1px 2px 0 rgba(0, 0, 0, .06);
+		}
+
+		.article_image {
+			background-position: center;
+			background-size: cover;
+			background-color: rgba(209, 213, 219, 1);
+			@include bradius(.25rem);
+			height: 8rem;
+		}
+
+		.mt-6 {
+			margin-top: 1.5rem;
+		}
+
+		.body {
+			display: flex;
+			flex-grow: 1;
+			flex-direction: column;
+		}
+
+		.article_title {
+			letter-spacing: .025em;
+			font-size: 1.125rem;
+			line-height: 1.75rem;
+			margin-bottom: .5rem;
+		}
+
+		.article_teaser {
+			font-size: .875rem;
+			line-height: 1.25rem;
+		}
+	}
+}

--- a/src/Themes/default/css/light_portal/sass/frontpage_simple2.scss
+++ b/src/Themes/default/css/light_portal/sass/frontpage_simple2.scss
@@ -1,0 +1,189 @@
+.article_simple2_view {
+	.card {
+		box-shadow: 0 20px 25px -5px rgba(0, 0, 0, .1), 0 10px 10px -5px rgba(0, 0, 0, .04);
+		flex-direction: column;
+		height: 18rem;
+		@include bradius(.5rem);
+		align-items: center;
+		display: flex;
+		position: relative;
+		margin-left: .5rem;
+		margin-right: .5rem;
+		margin: .4em;
+
+		@media (min-width: 768px) {
+			flex-direction: row;
+			box-shadow: 0 20px 25px -5px rgba(0, 0, 0, .1), 0 10px 10px -5px rgba(0, 0, 0, .04);
+			height: 18rem;
+		}
+
+		.card-header {
+			overflow: hidden;
+			z-index: 0;
+			position: relative;
+			order: 1;
+			height: 20rem;
+			width: 100%;
+			@include bradius(.5rem);
+
+			@media (min-width: 768px) {
+				@include bradius(0);
+				border-top-right-radius: .5rem;
+				border-bottom-right-radius: .5rem;
+				width: 40%;
+				height: 100%;
+				order: 2;
+			}
+
+			.card-image {
+				object-position: center;
+				object-fit: fill;
+				background-position: bottom;
+				background-size: cover;
+				background-blend-mode: multiply;
+				background-color: rgba(96, 165, 250, .3);
+				width: 100%;
+				height: 100%;
+				top: 0;
+				right: 0;
+				bottom: 0;
+				left: 0;
+				position: absolute;
+			}
+
+			.card-title {
+				display: flex;
+				flex-direction: column-reverse;
+				align-items: flex-start;
+				justify-content: flex-start;
+				background-image: linear-gradient(to bottom, transparent, transparent, #111827);
+				top: 0;
+				right: 0;
+				bottom: 0;
+				left: 0;
+				height: 100%;
+				position: absolute;
+				padding: 1.5rem;
+				padding-bottom: 1.5rem;
+
+				@media (min-width: 768px) {
+					display: none;
+				}
+
+				h3 {
+					line-height: 1.25;
+					width: 100%;
+					color: rgba(255, 255, 255, 1);
+					font-weight: 700;
+					font-size: 1.5rem;
+					margin-bottom: .5rem;
+				}
+
+				time {
+					color: rgba(243, 244, 246, 1);
+				}
+			}
+
+			svg {
+				color: rgba(255, 255, 255, 1);
+				fill: currentColor;
+				width: 6rem;
+				height: 100%;
+				display: none;
+				margin-left: -3rem;
+				top: 0;
+				bottom: 0;
+				position: absolute;
+
+				@media (min-width: 768px) {
+					display: block;
+				}
+			}
+		}
+
+		.card-body {
+			order: 2;
+			width: 100%;
+			align-items: center;
+			height: 100%;
+			display: flex;
+			margin-top: -1.5rem;
+
+			@media (min-width: 768px) {
+				width: 60%;
+				margin-top: 0;
+				order: 1;
+			}
+
+			.card-body-inner {
+				width: 100%;
+				box-shadow: 0 10px 10px -5px rgba(0, 0, 0, .04);
+				padding: 2rem;
+				background-color: rgba(255, 255, 255, 1);
+				@include bradius(.5rem);
+				height: 100%;
+				margin-left: .5rem;
+				margin-right: .5rem;
+
+				@media (min-width: 768px) {
+					box-shadow: none;
+					padding-left: 3.5rem;
+					padding-bottom: 3rem;
+					@include bradius(0);
+					border-top-left-radius: .5rem;
+					border-bottom-left-radius: .5rem;
+					margin-left: 0;
+					margin-right: 0;
+				}
+
+				h3,
+				time {
+					display: none;
+
+					@media (min-width: 768px) {
+						display: block;
+					}
+				}
+
+				h3 {
+					font-weight: 700;
+					font-size: 1.2rem;
+					line-height: 1.2rem;
+				}
+
+				time {
+					line-height: 1.75rem;
+					color: rgba(156, 163, 175, 1);
+				}
+
+				.article_teaser {
+					overflow: hidden;
+					display: -webkit-box;
+					-webkit-line-clamp: 3;
+					-webkit-box-orient: vertical;
+					line-height: 1.4em;
+					text-align: justify;
+				}
+
+				.read_more {
+					display: flex;
+					margin-top: .75rem;
+					text-decoration: none;
+
+					span {
+						&:first-child {
+							&:hover {
+								text-decoration: underline;
+							}
+						}
+					}
+
+					.arrow {
+						font-size: .75rem;
+						margin-left: .25rem;
+					}
+				}
+			}
+		}
+	}
+}

--- a/src/Themes/default/css/light_portal/sass/frontpage_simple3.scss
+++ b/src/Themes/default/css/light_portal/sass/frontpage_simple3.scss
@@ -1,0 +1,59 @@
+.article_simple3_view {
+	display: grid;
+	grid-template-columns: repeat(1, minmax(0, 1fr));
+	gap: 1.25rem;
+
+	@media (min-width: 768px) {
+		grid-template-columns: repeat(1, minmax(0, 1fr));
+	}
+
+	@media (min-width: 1024px) {
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+	}
+
+	@media (min-width: 1280px) {
+		grid-template-columns: repeat(3, minmax(0, 1fr));
+	}
+
+	> div {
+		@include bradius(.25rem);
+		overflow: hidden;
+		box-shadow: 0 10px 15px -3px rgba(0, 0, 0, .1), 0 4px 6px -2px rgba(0, 0, 0, .05);
+
+		img {
+			width: 100%;
+		}
+
+		.title {
+			padding: 1rem 1.5rem;
+
+			div {
+				font-weight: 700;
+				font-size: 1.25rem;
+				margin-bottom: .5rem;
+
+				a {
+					line-height: 1.2em;
+				}
+			}
+		}
+
+		.tags {
+			padding: 1rem 1.5rem .5rem;
+
+			a {
+				display: inline-block;
+				padding: .25rem .75rem;
+				font-size: .875rem;
+				font-weight: 600;
+				margin-right: .5rem;
+				margin-bottom: .5rem;
+
+				&:hover {
+					border-bottom: 1px dashed #ef564f;
+					text-decoration: none;
+				}
+			}
+		}
+	}
+}

--- a/src/Themes/default/css/light_portal/sass/frontpage_spectre.scss
+++ b/src/Themes/default/css/light_portal/sass/frontpage_spectre.scss
@@ -1,0 +1,39 @@
+.article_spectre_view {
+	.card {
+		border: 0;
+		box-shadow: 0 0.25rem 1rem rgba(48,55,66,.15);
+		height: 100%;
+		@include bradius(.1rem);
+		display: flex;
+		flex-direction: column;
+
+		.card-image {
+			padding-top: .8rem;
+
+			img {
+				display: block;
+				height: auto;
+				width: 100%;
+				object-fit: cover;
+			}
+		}
+
+		.card-header {
+			padding: .8rem;
+
+			.card-title {
+				font-size: 1rem;
+				font-weight: 500;
+			}
+
+			.card-subtitle {
+				color: #bcc3ce !important;
+			}
+		}
+
+		.card-body {
+			flex: 1 1 auto;
+			padding: 0.8rem;
+		}
+	}
+}

--- a/src/Themes/default/css/light_portal/sass/hacks.scss
+++ b/src/Themes/default/css/light_portal/sass/hacks.scss
@@ -1,0 +1,178 @@
+.block_bbc,
+.block_html,
+.block_markdown {
+	.videocontainer {
+		margin: 0 auto;
+	}
+}
+
+.preview .button {
+	float: none !important;
+}
+
+#info_center {
+	margin-bottom: 5px;
+}
+
+#admin_form_wrapper {
+	p {
+		&.errorbox {
+			margin: 0;
+		}
+	}
+}
+
+.descbox {
+	details {
+		code {
+			white-space: break-spaces !important;
+		}
+	}
+}
+
+.errorbox {
+	color: initial !important;
+}
+
+.action_admin {
+	&.sceditor-maximize {
+		#main_menu,
+		#genericmenu {
+			display: none;
+		}
+	}
+}
+
+#lp_post {
+	.centertext {
+		.button {
+			margin-left: 4px;
+		}
+	}
+
+	@media (max-width: 600px) {
+		.button {
+			float: none !important;
+			width: 100%;
+			margin-left: 0 !important;
+		}
+	}
+}
+
+.col-xs-12 {
+	.pagesection {
+		.button {
+			margin: 2px;
+		}
+	}
+}
+
+.sceditor-container {
+	position: relative;
+	min-height: 300px !important;
+}
+
+.priority,
+.status,
+.actions {
+	span {
+		@include pointer;
+	}
+}
+
+.lp_default_blocks,
+.lp_additional_blocks {
+	margin-bottom: 10px !important;
+
+	th {
+		&.icon,
+		&.actions {
+			width: 8%;
+		}
+	}
+}
+
+.handle {
+	cursor: grab;
+}
+
+.additional_row {
+	.button {
+		margin-left: 2px;
+	}
+}
+
+@media (max-width: 887px) {
+	.information {
+		.righttext {
+			text-align: center;
+		}
+	}
+	.descbox {
+		&.alternative2 {
+			display: block;
+		}
+	}
+}
+
+/* Animations */
+@-webkit-keyframes fadeIn {
+	from {
+		opacity: 0;
+	}
+	to {
+		opacity: 1;
+	}
+}
+
+@keyframes fadeIn {
+	from {
+		opacity: 0;
+	}
+	to {
+		opacity: 1;
+	}
+}
+
+/* Virtual Select */
+.vscomp-value-tag {
+	background: $tag-bg-color;
+	border: 0 solid $tag-border-color;
+	color: $tag-color;
+	margin: 0 3px 3px 0;
+	padding: 2px 6px;
+	@include pointer;
+	@include bradius(0);
+
+	&[data-value^="!"] {
+		background: $ignore-action;
+	}
+}
+.vscomp-value {
+	height: auto !important;
+	width: 98%;
+
+	div {
+		margin: 0 !important;
+	}
+
+	i {
+		margin-right: .5em;
+	}
+}
+.vscomp-option-text {
+	div {
+		margin: 0 !important;
+	}
+}
+
+/* RTL */
+[dir=rtl] {
+	.gear {
+		right: -5px !important;
+	}
+
+	i[class] {
+		transform: scaleX(-1);
+	}
+}

--- a/src/Themes/default/css/light_portal/sass/index.php
+++ b/src/Themes/default/css/light_portal/sass/index.php
@@ -1,0 +1,6 @@
+<?php
+
+if (file_exists(dirname(__DIR__) . '/index.php'))
+	include (dirname(__DIR__) . '/index.php');
+else
+	exit;

--- a/src/Themes/default/css/light_portal/sass/layout.scss
+++ b/src/Themes/default/css/light_portal/sass/layout.scss
@@ -1,0 +1,80 @@
+#lp_layout {
+	h3,
+	h4 {
+		&:hover {
+			white-space: normal;
+		}
+	}
+
+	.file_content {
+		white-space: break-spaces;
+	}
+
+	#post_confirm_buttons {
+		padding: 12px 0 0 0 !important;
+	}
+
+	.row {
+		> aside {
+			margin: 0 !important;
+		}
+
+		flex-wrap: wrap;
+	}
+
+	.between-xs + .row,
+	.row + .between-xs {
+		margin-top: 5px;
+	}
+
+	.sticky_sidebar {
+		position: sticky;
+		position: -webkit-sticky;
+		top: 5px;
+
+		.button {
+			float: none;
+			width: 100%;
+		}
+	}
+
+	aside {
+		> div {
+			> h3,
+			> h4 {
+				white-space: nowrap;
+				text-overflow: ellipsis;
+				i {
+					margin-right: .5em;
+				}
+			}
+
+			margin: 0;
+		}
+
+		.progress_bar {
+			max-width: initial;
+		}
+
+		&[id^="block"]:not(:first-child) {
+			clear: both;
+			margin-top: 4px;
+		}
+
+		.block_edit {
+			opacity: .5;
+
+			&:hover {
+				opacity: 1;
+			}
+		}
+	}
+
+	@media (max-width: 720px) {
+		input {
+			&[type="radio"] {
+				width: auto;
+			}
+		}
+	}
+}

--- a/src/Themes/default/css/light_portal/sass/layout_switcher.scss
+++ b/src/Themes/default/css/light_portal/sass/layout_switcher.scss
@@ -1,0 +1,9 @@
+.layout_switcher {
+	margin: 1px 0 5px 0;
+
+	form {
+		display: flex;
+		justify-content: space-between;
+		gap: 10px;
+	}
+}

--- a/src/Themes/default/css/light_portal/sass/menu.scss
+++ b/src/Themes/default/css/light_portal/sass/menu.scss
@@ -1,0 +1,15 @@
+.fa-portal {
+	&::before {
+		content: "\f0ac";
+	}
+}
+
+.portal_menu_icons {
+	font-size: .875rem;
+	vertical-align: middle;
+
+	&.fas,
+	&.far {
+		margin: -3px 8px 0 0;
+	}
+}

--- a/src/Themes/default/css/light_portal/sass/page.scss
+++ b/src/Themes/default/css/light_portal/sass/page.scss
@@ -1,0 +1,26 @@
+.infobox {
+	display: flex;
+	place-items: center;
+	justify-content: space-between;
+
+	.button {
+		margin-left: 4px;
+	}
+}
+
+section {
+	#display_head {
+		margin-top: .1em;
+		margin-bottom: 0;
+
+		span {
+			margin: 0;
+		}
+	}
+
+	article {
+		.button {
+			margin: 2px auto;
+		}
+	}
+}

--- a/src/Themes/default/css/light_portal/sass/page_comments.scss
+++ b/src/Themes/default/css/light_portal/sass/page_comments.scss
@@ -1,0 +1,266 @@
+.comments {
+	margin-top: 1em;
+
+	.cat_bar {
+		@include bradius;
+	}
+
+	.pagesection {
+		button {
+			&:disabled {
+				opacity: 0.5;
+				pointer-events: none;
+			}
+		}
+	}
+
+	.bbc_list {
+		list-style-type: initial;
+	}
+
+	.bbc_code {
+		overflow: hidden !important;
+	}
+
+	markdown-toolbar {
+		display: flex;
+		gap: 10px;
+		align-items: center;
+		margin-bottom: 4px;
+	}
+
+	.reply_form {
+		textarea {
+			resize: none;
+			width: 100%;
+			height: 100px;
+		}
+
+		button {
+			float: left;
+			margin-top: 10px;
+
+			&[name='comment'] {
+				float: right;
+
+				&[disabled] {
+					opacity: 0.5;
+					cursor: not-allowed;
+				}
+			}
+		}
+	}
+
+	.fade-enter-active,
+	.fade-move {
+		transition: 0.4s ease all;
+	}
+
+	.fade-enter-from,
+	.fade-leave-to {
+		opacity: 0;
+		transform: scale(0.6);
+	}
+
+	.fade-leave-active {
+		transition: 0.4s ease all;
+		position: absolute;
+	}
+
+	.fade-list-enter-active,
+	.fade-list-leave-active {
+		transition: 0.4s ease all;
+	}
+
+	.fade-list-enter-from,
+	.fade-list-leave-to {
+		transform: translateY(10px);
+		opacity: 0;
+	}
+}
+
+.comment {
+	&_list {
+		list-style: none;
+		margin: auto 0;
+		position: relative;
+
+		li {
+			clear: both;
+			width: 100%;
+		}
+
+		@media (max-width: 600px) {
+			.col-xs-12 {
+				flex-basis: 95%;
+				margin-left: 10px;
+			}
+		}
+	}
+
+	&_avatar {
+		position: absolute;
+		width: 74px;
+		left: 10px;
+		@include valign(top);
+
+		@media (max-width: 600px) {
+			display: none;
+		}
+
+		.avatar {
+			max-width: 45px !important;
+			max-height: 45px !important;
+			box-shadow: 0 0 4px #666;
+			@include bradius(100%);
+		}
+	}
+
+	&_wrapper {
+		width: 100%;
+		padding-left: 55px;
+
+		.comment_entry {
+			display: block;
+			position: relative;
+			padding: 0 12px 8px;
+			border: 1px solid $color-light-gray;
+			box-shadow: 0 2px 5px rgba(0, 0, 0, .1);
+			@include bradius(7px);
+
+			.edit_form {
+				textarea {
+					resize: none;
+					width: 100%;
+					height: 100px;
+				}
+
+				.comment_edit_buttons {
+					display: flex;
+					justify-content: left;
+					gap: 10px;
+					margin-top: 6px;
+					padding-top: 6px;
+					border-top: 1px dashed #bfbfbf;
+
+					[role='button'] {
+						opacity: 0.6;
+
+						&:hover {
+							opacity: 1;
+							@include pointer;
+						}
+					}
+				}
+			}
+		}
+
+		@media (max-width: 600px) {
+			padding: 0 !important;
+		}
+	}
+
+	&_title {
+		display: flex;
+		justify-content: space-between;
+		font-size: .7rem;
+		margin: -1px -13px 10px;
+		line-height: 20px;
+
+		> span {
+			font-weight: bold;
+			border: 1px solid $color-light-gray;
+			display: inline-block;
+			padding: 6px 11px;
+			@include bradius(7px, 0, 7px, 0);
+			@include valign(top);
+		}
+
+		.comment_date {
+			border: 1px solid $color-light-gray;
+			display: inline-block;
+			padding: 6px 11px;
+			opacity: .8;
+			@include bradius(0, 7px, 0, 7px);
+			@include valign(top);
+
+			.bbc_link {
+				margin-left: 10px;
+			}
+		}
+	}
+
+	&_content {
+		padding: .2em 1em;
+	}
+
+	&_buttons {
+		display: flex;
+		justify-content: space-between;
+		gap: 10px;
+		margin-top: 6px;
+		padding-top: 6px;
+		border-top: 1px dashed $comment-smalltext-color;
+
+		[role='button'] {
+			opacity: .6;
+
+			&:hover {
+				opacity: 1;
+				@include pointer;
+			}
+
+			&:last-child {
+				margin-left: auto;
+				margin-right: 0;
+			}
+		}
+	}
+}
+
+[dir=rtl] {
+	.comment_wrapper {
+		padding: 0 55px 0 0;
+	}
+
+	.comment_avatar {
+		right: 10px;
+
+		img {
+			transform: scaleX(-1);
+		}
+	}
+
+	.comment_title span.bg {
+		@include bradius(0, 7px, 0, 7px);
+	}
+
+	.comment_date {
+		@include bradius(7px, 0, 7px, 0);
+	}
+
+	.comment_buttons {
+		span {
+			margin-right: 0;
+
+			&:last-child {
+				margin-left: 0;
+				margin-right: auto;
+			}
+		}
+	}
+
+	.reply_form {
+		button {
+			float: right !important;
+
+			&[name='comment'] {
+				float: left !important;
+			}
+		}
+	}
+
+	.comment_edit_buttons {
+		justify-content: right !important;
+	}
+}

--- a/src/Themes/default/css/light_portal/sass/page_related.scss
+++ b/src/Themes/default/css/light_portal/sass/page_related.scss
@@ -1,0 +1,28 @@
+.related_pages {
+	margin-top: 1em;
+
+	.cat_bar {
+		@include bradius;
+	}
+
+	.list {
+		display: grid;
+		grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+		grid-gap: 0 10px;
+
+		& > div {
+			display: flex;
+			flex-direction: column;
+			justify-content: space-between;
+			text-align: center;
+		}
+
+		@media (max-width: 480px) {
+			grid-template-columns: 1fr;
+		}
+
+		@media (min-width: 481px) and (max-width: 600px) {
+			grid-template-columns: repeat(2, 1fr);
+		}
+	}
+}

--- a/src/Themes/default/css/light_portal/sass/portal.scss
+++ b/src/Themes/default/css/light_portal/sass/portal.scss
@@ -1,0 +1,39 @@
+@import "_variables";
+@import "_functions";
+
+/* Layouts */
+@import "layout_switcher";
+@import "frontpage_default";
+@import "frontpage_alt";
+@import "frontpage_alt2";
+@import "frontpage_alt3";
+@import "frontpage_simple";
+@import "frontpage_simple2";
+@import "frontpage_simple3";
+@import "frontpage_flarum";
+@import "frontpage_spectre";
+
+/* Menu, main layout, blocks */
+@import "menu";
+@import "layout";
+@import "blocks";
+
+/* Page template */
+@import "page";
+@import "page_related";
+@import "page_comments";
+
+/* Portal admin area */
+@import "admin_settings";
+@import "admin_context";
+@import "admin_tabs";
+@import "admin_checkbox";
+@import "admin_blocks";
+@import "admin_pages";
+@import "admin_plugins";
+@import "admin_categories";
+
+@import "badges";
+
+/* Custom fixes */
+@import "hacks";


### PR DESCRIPTION
Sass will only be used by default during development.
Less has been left as an alternative option for now.
There will be no compilers in the production version.

Closes #172 