### PR TITLE
Add platform key in config section

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,11 @@
     "phing/phing": "3.*"
   },
   "minimum-stability": "alpha",
+  "config": {
+    "platform": {
+      "php": "8.0"
+    }
+  },
   "scripts": {
     "check": "vendor/bin/rector process --dry-run --clear-cache",
     "assets": [

--- a/src/Sources/LightPortal/composer.json
+++ b/src/Sources/LightPortal/composer.json
@@ -18,7 +18,10 @@
     "vendor-dir": "Libs",
     "optimize-autoloader": true,
     "preferred-install": "dist",
-    "sort-packages": true
+    "sort-packages": true,
+    "platform": {
+      "php": "8.0"
+    }
   },
   "scripts": {
     "post-update-cmd": [


### PR DESCRIPTION
Update dependencies for PHP 8.0 only, ignoring the currently installed version